### PR TITLE
Explicitly set perturbation parameters

### DIFF
--- a/dig/sslgraph/method/contrastive/model/graphcl.py
+++ b/dig/sslgraph/method/contrastive/model/graphcl.py
@@ -45,10 +45,10 @@ class GraphCL(Contrastive):
             'BPhi': BandpassFiltering(band='hi'),
             'BPmid': BandpassFiltering(band='mid'),
             'BPlo': BandpassFiltering(band='lo'),
-            'WBhi': WaveletBankFiltering(bands=[True, False, False]),
-            'WBmid': WaveletBankFiltering(bands=[False, True, False]),
-            'WBlo': WaveletBankFiltering(bands=[False, False, True]),
-            'Fiedler': FiedlerFragmentation()
+            'WBhi': WaveletBankFiltering(bands=[True, False, False], norm="sym"),
+            'WBmid': WaveletBankFiltering(bands=[False, True, False], norm="sym"),
+            'WBlo': WaveletBankFiltering(bands=[False, False, True], norm="sym"),
+            'Fiedler': FiedlerFragmentation(num_iter=200, max_size=10, method="full")
         }
 
         for aug in [aug_1, aug_2]:


### PR DESCRIPTION
There's a bug with using hydra joblib launcher that does not set the graphgym cfg correctly, which then causes error when initializing the perturbation objects as they try to read default settings from the cfg. To resolve this, I explicitly set all input parameters for the perturbatino objects so that they do not attempt to read from cfg.